### PR TITLE
Add release workflow and update integration name to Open-Meteo Enhanced

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version (e.g. 0.2.0)"
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Validate version format
+        run: |
+          if ! echo "${{ inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version format. Use semver (e.g. 0.2.0)"
+            exit 1
+          fi
+
+      - name: Check tag does not already exist
+        run: |
+          if git rev-parse "v${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "::error::Tag v${{ inputs.version }} already exists"
+            exit 1
+          fi
+
+      - name: Update manifest.json version
+        run: |
+          sed -i 's/"version": "[^"]*"/"version": "${{ inputs.version }}"/' \
+            custom_components/open_meteo_local/manifest.json
+
+      - name: Commit and tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add custom_components/open_meteo_local/manifest.json
+          git commit -m "Release v${{ inputs.version }}"
+          git tag "v${{ inputs.version }}"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" HEAD --tags
+
+      - name: ZIP open_meteo_local Dir
+        run: |
+          cd ${{ github.workspace }}/custom_components/open_meteo_local
+          zip open_meteo_local.zip -r ./
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          tag_name: "v${{ inputs.version }}"
+          generate_release_notes: true
+          prerelease: true
+          files: ${{ github.workspace }}/custom_components/open_meteo_local/open_meteo_local.zip

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: HACS validation
-        uses: hacs/action@main
+        uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main
         with:
           category: integration
 
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Hassfest validation
-        uses: home-assistant/actions/hassfest@master
+        uses: home-assistant/actions/hassfest@e91ad1948e57189485b9c1ad608af0c303946f89 # master

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Open-Meteo Local
+# Open-Meteo Enhanced
 
 [![HACS Validation](https://github.com/sayurin/open_meteo_local/actions/workflows/validate.yml/badge.svg)](https://github.com/sayurin/open_meteo_local/actions/workflows/validate.yml)
 
@@ -77,7 +77,7 @@ This integration provides more accurate condition mapping:
 2. Add this repository as a custom repository:
    - URL: `https://github.com/sayurin/open_meteo_local`
    - Category: Integration
-3. Search for "Open-Meteo local" and install it.
+3. Search for "Open-Meteo Enhanced" and install it.
 4. Restart Home Assistant.
 
 ### Manual
@@ -88,7 +88,7 @@ This integration provides more accurate condition mapping:
 ## Configuration
 
 1. Go to **Settings** → **Devices & Services** → **Add Integration**.
-2. Search for **Open-Meteo local**.
+2. Search for **Open-Meteo Enhanced**.
 3. Select a zone to use for the weather location.
 
 The integration creates a weather entity bound to the selected zone. The location (latitude/longitude) is read from the zone entity, so updating the zone will update the weather data location.

--- a/custom_components/open_meteo_local/manifest.json
+++ b/custom_components/open_meteo_local/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "open_meteo_local",
-  "name": "Open-Meteo local",
+  "name": "Open-Meteo Enhanced",
   "codeowners": ["@sayurin"],
   "config_flow": true,
   "dependencies": ["zone"],
@@ -8,6 +8,6 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/sayurin/open_meteo_local/issues",
-  "requirements": ["openmeteo-sdk==1.26.0"],
+  "requirements": ["openmeteo-sdk==1.27.2"],
   "version": "0.1.1"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,3 +1,5 @@
 {
-  "name": "Open Meteo local"
+  "name": "Open-Meteo Enhanced",
+  "zip_release": true,
+  "filename": "open_meteo_local.zip"
 }


### PR DESCRIPTION
- Introduced a GitHub Actions workflow for releasing new versions.
- Updated integration name in README, manifest, and HACS files to "Open-Meteo Enhanced".
- Changed version requirement for openmeteo-sdk to 1.27.2.