### PR TITLE
Remove future annotations import from all files

### DIFF
--- a/custom_components/open_meteo_local/__init__.py
+++ b/custom_components/open_meteo_local/__init__.py
@@ -1,7 +1,5 @@
 """Support for Open-Meteo."""
 
-from __future__ import annotations
-
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 

--- a/custom_components/open_meteo_local/config_flow.py
+++ b/custom_components/open_meteo_local/config_flow.py
@@ -1,7 +1,5 @@
 """Config flow to configure the Open-Meteo integration."""
 
-from __future__ import annotations
-
 from typing import Any
 
 import voluptuous as vol

--- a/custom_components/open_meteo_local/const.py
+++ b/custom_components/open_meteo_local/const.py
@@ -1,7 +1,5 @@
 """Constants for the Open-Meteo integration."""
 
-from __future__ import annotations
-
 from datetime import timedelta
 import logging
 from typing import Final

--- a/custom_components/open_meteo_local/coordinator.py
+++ b/custom_components/open_meteo_local/coordinator.py
@@ -1,7 +1,5 @@
 """DataUpdateCoordinator for the Open-Meteo integration."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 

--- a/custom_components/open_meteo_local/diagnostics.py
+++ b/custom_components/open_meteo_local/diagnostics.py
@@ -1,7 +1,5 @@
 """Diagnostics support for Open-Meteo."""
 
-from __future__ import annotations
-
 from dataclasses import asdict
 from typing import Any
 

--- a/custom_components/open_meteo_local/weather.py
+++ b/custom_components/open_meteo_local/weather.py
@@ -1,7 +1,5 @@
 """Support for Open-Meteo weather."""
 
-from __future__ import annotations
-
 from homeassistant.components.weather import (
     Forecast,
     SingleCoordinatorWeatherEntity,


### PR DESCRIPTION
Eliminate the unnecessary import of future annotations across all files related to the Open-Meteo integration.